### PR TITLE
Add composer.json to describe the package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,17 @@
+{
+	"name": "alleyinteractive/debug-bar-searchpress",
+	"type": "wordpress-plugin",
+	"description": "Debug Bar SearchPress Add-on",
+	"homepage": "https://github.com/alleyinteractive/debug-bar-searchpress",
+	"license": "GPL-2.0-or-later",
+	"authors": [
+		{
+			"name": "Alley",
+			"homepage": "https://alley.co/"
+		}
+	],
+	"support": {
+		"issues": "https://github.com/alleyinteractive/debug-bar-searchpress/issues",
+		"source": "https://github.com/alleyinteractive/debug-bar-searchpress"
+	}
+}


### PR DESCRIPTION
This PR adds a composer.json file that describes the package and sets its type to `wordpress-plugin`, which enables installation via Composer.